### PR TITLE
Cmake Build system + static linkage

### DIFF
--- a/sdk/sdk/CMakeLists.txt
+++ b/sdk/sdk/CMakeLists.txt
@@ -3,8 +3,7 @@ cmake_minimum_required(VERSION 3.10)
 
 file(GLOB base_sources src/*.cpp src/hal/*.cpp)
 file(GLOB base_includes src/*.h src/*.hpp src/hal/*.h src/hal/*.hpp)
-# glob shared C++ sources
-add_library(rplidar_sdk SHARED ${base_sources} ${platform_srcs})
+
 # Check if Windows, exclude MinGW
 if (WIN32 AND NOT MINGW)
     message(STATUS "Detected Windows target...")
@@ -26,11 +25,13 @@ else ()
     message(FATAL_ERROR "Unknown platform ${CMAKE_SYSTEM_NAME}, build cannot continue.")
 endif ()
 
-
+# glob shared C++ sources
+add_library(rplidar_sdk STATIC ${base_sources} ${platform_srcs})
 
 target_include_directories(
         rplidar_sdk INTERFACE include src
 )
+
 include_directories(src src/hal include)
 
 install(

--- a/sdk/sdk/CMakeLists.txt
+++ b/sdk/sdk/CMakeLists.txt
@@ -35,6 +35,6 @@ include_directories(src src/hal include)
 
 install(
         TARGETS rplidar_sdk
-        DESTINATION rplidar_sdk EXPORT rplidar_sdk
+        DESTINATION .
 )
 

--- a/sdk/sdk/CMakeLists.txt
+++ b/sdk/sdk/CMakeLists.txt
@@ -3,12 +3,14 @@ cmake_minimum_required(VERSION 3.10)
 
 file(GLOB base_sources src/*.cpp src/hal/*.cpp)
 file(GLOB base_includes src/*.h src/*.hpp src/hal/*.h src/hal/*.hpp)
-
+# glob shared C++ sources
+add_library(rplidar_sdk SHARED ${base_sources} ${platform_srcs})
 # Check if Windows, exclude MinGW
 if (WIN32 AND NOT MINGW)
     message(STATUS "Detected Windows target...")
     file(GLOB platform_srcs src/arch/win32/*.hpp src/arch/win32/*.cpp)
     include_directories(src/arch/win32)
+    target_include_directories(rplidar_sdk PUBLIC src/arch/win32)
 elseif (MINGW)
     # Library doesn't build under MinGW, no idea why.
     message(FATAL_ERROR "Mingw is presently not supported.")
@@ -16,18 +18,22 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES Linux)
     message(STATUS "linux target...")
     file(GLOB platform_srcs src/arch/linux/*.hpp src/arch/linux/*.cpp)
     include_directories(src/arch/linux)
+    target_include_directories(rplidar_sdk PUBLIC src/arch/linux)
 
 elseif (${CMAKE_SYSTEM_NAME} MATCHES Darwin)
     message(STATUS "Apple Mac OS X target...")
     file(GLOB platform_srcs src/arch/macOS/*.hpp src/arch/macOS/*.cpp)
     include_directories(src/arch/macOS)
+    target_include_directories(rplidar_sdk PUBLIC src/arch/macOS)
 else ()
     message(FATAL_ERROR "Unknown platform ${CMAKE_SYSTEM_NAME}, build cannot continue.")
 endif ()
 
 
-# glob shared C++ sources
-add_library(rplidar_sdk SHARED ${base_sources} ${platform_srcs})
+
+target_include_directories(
+        rplidar_sdk PUBLIC src src/hal include
+)
 include_directories(src src/hal include)
 
 install(

--- a/sdk/sdk/CMakeLists.txt
+++ b/sdk/sdk/CMakeLists.txt
@@ -10,7 +10,6 @@ if (WIN32 AND NOT MINGW)
     message(STATUS "Detected Windows target...")
     file(GLOB platform_srcs src/arch/win32/*.hpp src/arch/win32/*.cpp)
     include_directories(src/arch/win32)
-    target_include_directories(rplidar_sdk PUBLIC src/arch/win32)
 elseif (MINGW)
     # Library doesn't build under MinGW, no idea why.
     message(FATAL_ERROR "Mingw is presently not supported.")
@@ -18,13 +17,11 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES Linux)
     message(STATUS "linux target...")
     file(GLOB platform_srcs src/arch/linux/*.hpp src/arch/linux/*.cpp)
     include_directories(src/arch/linux)
-    target_include_directories(rplidar_sdk PUBLIC src/arch/linux)
 
 elseif (${CMAKE_SYSTEM_NAME} MATCHES Darwin)
     message(STATUS "Apple Mac OS X target...")
     file(GLOB platform_srcs src/arch/macOS/*.hpp src/arch/macOS/*.cpp)
     include_directories(src/arch/macOS)
-    target_include_directories(rplidar_sdk PUBLIC src/arch/macOS)
 else ()
     message(FATAL_ERROR "Unknown platform ${CMAKE_SYSTEM_NAME}, build cannot continue.")
 endif ()
@@ -32,7 +29,7 @@ endif ()
 
 
 target_include_directories(
-        rplidar_sdk PUBLIC src src/hal include
+        rplidar_sdk INTERFACE include src
 )
 include_directories(src src/hal include)
 

--- a/sdk/sdk/CMakeLists.txt
+++ b/sdk/sdk/CMakeLists.txt
@@ -30,5 +30,8 @@ endif ()
 add_library(rplidar_sdk SHARED ${base_sources} ${platform_srcs})
 include_directories(src src/hal include)
 
-install(TARGETS rplidar_sdk DESTINATION rplidar_sdk)
+install(
+        TARGETS rplidar_sdk
+        DESTINATION rplidar_sdk EXPORT rplidar_sdk
+)
 


### PR DESCRIPTION
This lib will now be built as a static package instead of dynamic.
this does require the build to have `-fPIC` in compile options to be able to link from dynamic libraries.